### PR TITLE
Fix link to paper in README.pdf, use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ informed the POPL PC chair of the mistake, and the PC chair advised us to
 create a page like this one and update the PDF paper and corresponding talk.
 
 An updated version of the paper is available here:
-[http://cseweb.ucsd.edu/~mandrysc/pub/dtoa.pdf]().
+[https://cseweb.ucsd.edu/~mandrysc/pub/dtoa.pdf](https://cseweb.ucsd.edu/~mandrysc/pub/dtoa.pdf).


### PR DESCRIPTION
This updates the markdown hyperlink in the README to point to the actual paper instead of an error page so users don't have to copy-paste the link URL.  Also updates to https as a general best practice.
